### PR TITLE
Add support for additional markup languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Vale automatically checks a document when you open or save it.  Use the `Vale: L
 
 Vale always runs from the workspace directory in either case, so if you put a [Vale configuration][config] in the workspace directory it will automatically pick it up.
 
-Currently this extension only supports **Markdown documents**; please [open an issue][issue] or a pull request if you need support for **more document formats**, provided that [Vale][] supports them.
+Currently this extension only supports **Markdown, reStructuredText, LaTeX and plain text (.txt) documents**; please [open an issue][issue] or a pull request if you need support for **more document formats**, provided that [Vale][] supports them.
 
 [config]: https://valelint.github.io/docs/config/
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         }
     },
     "activationEvents": [
-        "onLanguage:markdown"
+        "onLanguage:plaintext"
     ],
     "main": "./out/src/extension",
     "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,8 +45,7 @@ import {
  * @return Whether the document is elligible
  */
 const isElligibleDocument = (document: TextDocument): boolean =>
-    !document.isDirty && 0 < languages.match({
-        language: "markdown",
+    !document.isDirty && 0 < languages.match({ 
         scheme: "file",
     }, document);
 
@@ -265,7 +264,7 @@ const runValeOnWorkspace = async (): Promise<ValeDiagnostics> => {
     // Explicitly find all elligible files ourselves so that we respect
     // "files.exclude", ie, only look at files that are included in the
     // workspace.
-    const extensions: ReadonlyArray<string> = ["md", "markdown"];
+    const extensions: ReadonlyArray<string> = ["md", "markdown", "txt", "rst", "tex"];
     const pattern = `**/*.{${extensions.join(",")}}`;
     const uris = await workspace.findFiles(pattern);
     const results: ValeDiagnostics = new Map();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ import {
  * @return Whether the document is elligible
  */
 const isElligibleDocument = (document: TextDocument): boolean =>
-    !document.isDirty && 0 < languages.match({ 
+    !document.isDirty && 0 < languages.match({
         scheme: "file",
     }, document);
 


### PR DESCRIPTION
Closes #6. 
This commit adds support for all file endings Vale lints by default. One could go even further and read the list of file endings that should be considered from the vale configuration file (running "vale dc" on the command line), but I wanted to keep it simple for now.